### PR TITLE
Added recursive call to getRecord for paged results

### DIFF
--- a/updater-v2.php
+++ b/updater-v2.php
@@ -51,10 +51,10 @@ function getExternalIp()
  * @return bool
  * @throws Exception
  */
-function getRecord()
+function getRecord($page=null)
 {
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, API_URL . 'domains/' . DOMAIN . '/records');
+    curl_setopt($ch, CURLOPT_URL, API_URL . 'domains/' . DOMAIN . '/records'.($page != null ? '?page='.$page : ''));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, CURL_TIMEOUT);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -77,7 +77,17 @@ function getRecord()
             return $record;
         }
     }
-
+    
+    // Recursive call for pages results
+    if(isset($dataJson['links']['pages']['next']) && $dataJson['links']['pages']['next'] != '')
+    {
+	    $page = preg_match('/page=(?<page_number>\d+)/i', $dataJson['links']['pages']['next'], $match);
+	    if(isset($match['page_number']) && $match['page_number'] != '')
+	    {
+		    return getRecord($match['page_number']);
+	    }
+    }
+    
     return false;
 }
 


### PR DESCRIPTION
When there are > 30 records on a domain, the results of the /domains/DOMAIN/records call will be paged. I added a recursive call to the getRecord function which passes in a page number. In the event that the record wasn't found and there is found.

I'm unsure if results for API v1 are paged, I only made this change to the v2 version.