### PR TITLE
Making sure to use python3

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Original Script by Michael Shepanski (2013-08-01, python 2)
 # Updated to work with Python 3
 # Updated to use Digital Oean API v2


### PR DESCRIPTION
On my debian install I had to use python3 because python by default was 2.7 version.