### PR TITLE
add --ip flag

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -61,9 +61,10 @@ def put_url(url, data, headers):
         return data.decode('utf8')
 
 
-def get_external_ip(expected_rtype):
+def get_external_ip(expected_rtype, external_ip):
     """ Return the current external IP. """
-    external_ip = get_url(CHECKIP_URL).rstrip()
+    if external_ip == None:
+        external_ip = get_url(CHECKIP_URL).rstrip()
     ip = ipaddress.ip_address(external_ip)
     if (ip.version == 4 and expected_rtype != 'A') or (ip.version == 6 and expected_rtype != 'AAAA'):
         raise Exception('Expected Rtype {} but got {}'.format(expected_rtype, external_ip))
@@ -140,6 +141,7 @@ def process_args():
     parser.add_argument("record")
     parser.add_argument("rtype", choices=['A', 'AAAA'])
     parser.add_argument("-q", "--quiet", action="store_true", help='Only display output on IP change')
+    parser.add_argument("-i", "--ip", nargs='?', help='Use a given IPv4 or IPv6 address instead.', default=None)
     parser.add_argument("-ecoc", "--error-code-on-change", action="store_true", help='return Error Code 1 on IP change')
     return parser.parse_args()
 
@@ -151,7 +153,7 @@ def run():
             output.suppress = True
 
         output("Update {}.{}: {}", args.record, args.domain, datetime.now())
-        ipaddr = get_external_ip(args.rtype)
+        ipaddr = get_external_ip(args.rtype, args.ip)
         domain = get_domain(args.domain, args.token)
         record = get_record(domain, args.record, args.rtype, args.token)
         if record['data'] == ipaddr:


### PR DESCRIPTION
I was having issues with the web service you were using to get external IP's. It wasn't working for setting AAAA records because it was only returning IPv4 addresses.

I added a flag to your script so I can use a custom service to get IP's instead, such as "$(ip addr show | grep -m 1 -P -o '(?<=inet6 )(?!::1|fe80)[^/ ]*')" to get the first non loopback/link-local IPv6 address.